### PR TITLE
[project.py] fix batch_size issue training model (issue 187 kso-object)

### DIFF
--- a/kso_utils/project.py
+++ b/kso_utils/project.py
@@ -1,5 +1,6 @@
 # base imports
 import os
+import sys
 import glob
 import logging
 import asyncio
@@ -891,6 +892,13 @@ class MLProjectProcessor(ProjectProcessor):
         self.best_model_path = None
         self.model_type = None
         self.train, self.run, self.test = (None,) * 3
+        
+        # Before t6_utils gets loaded in, the val.py file in yolov5_tracker repository needs to be removed
+        # to prevent the batch_size error, see issue kso-object-detection #187
+        path_to_val = os.path.join(sys.path[0],'yolov5_tracker/val.py')
+        if os.path.exists(path_to_val):
+            os.remove(path_to_val)
+        
         self.modules = import_modules(["t4_utils", "t5_utils", "t6_utils", "t7_utils"])
         self.modules.update(
             import_modules(["torch", "wandb", "yaml", "yolov5"], utils=False)


### PR DESCRIPTION
A batch_size error occured when trying to train a model in Notebook 5. This error occurs since the commit where the project.py was created in commit 7c0d287. The error only occurs when yolov5.train(epochs=1) (or our code) is run after that the MLProjectProcessor class is created. Without this class, the code runs properly. In this class, t6_utils gets imported, which on its turn does: import yolov5_tracker.track as track. In that code, some paths are appended to the sys.path. As a result of this, when the validation.run() is called in the tolov5.train(), it does not run the val.py from yolov5, but it runs the val.py from the tracker.

This val.py from the tracker is never imported in the entire repository, so it is just not used. Therefore the solution to this problem is to delete the val.py in the tracker repository. This makes it possible to run Notebook 5 / train models without errors.

Removing this val.py automatically via the code is added in this commit.

For more information, see the issueboard kso-object-detection #187.